### PR TITLE
Add a ruby script to mark a subject as included.

### DIFF
--- a/subject_include.rb
+++ b/subject_include.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'json'
+obj = JSON.parse(File.read("./include/subjects.json"))
+
+for i in ARGV
+	if obj[i].is_a?(Array) && obj[i].length == 2 && obj[i][1] == false
+		obj[i] = true
+		puts "Toggled #{i}"
+	else
+		puts "#{i} is not a part of this JSON or was already marked true"
+	end
+end
+
+File.delete("./include/subjects.json")
+File.open("./include/subjects.json", "w") { |file| file.write(JSON.pretty_generate(obj)) }
+


### PR DESCRIPTION
- makes opening the json file legacy!
- another ruby script to make maintenance easy:

``` sh
>> $ ruby subject_include.rb EC60064 ME22004 ME41001
EC60064 not in the json
ME22004 toggled
ME41001 toggled
```
